### PR TITLE
docs: fixed deploy to github pages (#792) [skip publish]

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -56,18 +56,7 @@ jobs:
   GenerateDocumentation:
     name: Generate Static Documentation
     runs-on: ubuntu-latest
-    needs: Publish
-    services:
-      pokedex:
-        image: ghcr.io/favware/graphql-pokemon:latest
-        options: >-
-          --health-cmd "nc -z localhost 4000"
-          --health-interval 10s
-          --health-timeout 10s
-          --health-retries 6
-          --health-start-period 5s
-        ports:
-          - 4000:4000
+    # needs: Publish
     steps:
       - name: Checkout Project
         uses: actions/checkout@v3
@@ -85,34 +74,18 @@ jobs:
         run: yarn docs
       - name: Publish Docs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          REPO="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          echo -e "\n# Checkout the repo in the target branch"
-          TARGET_BRANCH="gh-pages"
-          git clone $REPO out -b $TARGET_BRANCH
-          echo -e "\n# Remove any old files in the out folder"
-          rm -rfv out/_app/*
-          rm -rfv out/introduction/*
-          rm -rfv out/queries/*
-          rm -rfv out/types/*
-          rm -rfv out/*.html
-          rm -rfv out/vite-manifest.json
-          echo -e "\n# Move the generated docs to the newly-checked-out repo, to be committed and pushed"
-          rsync -vaI .all-contributorsrc out/
-          rsync -vaI LICENSE.md out/
-          rsync -vaI README.md out/
-          rsync -vaI docs/ out/
-          echo -e "\n# Commit and push"
-          cd out
-          git add --all .
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_EMAIL}"
-          git commit -m "docs: magidocs docs build for ${GITHUB_SHA}" || true
-          git push origin $TARGET_BRANCH
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-          GITHUB_ACTOR: Favware-bot
-          GITHUB_EMAIL: favwarebot@gmail.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git config --global user.email "favwarebot@gmail.com"
+          git config --global user.name "Favware-bot"
+          echo "User-agent: *\nDisallow:" >> docs/robots.txt
+          touch docs/.nojekyll
+          cp .all-contributorsrc docs/
+          cp LICENSE.md docs/
+          cp README.md docs/
+          npx gh-pages --dist docs --dotfiles true --message "docs: magidocs docs build for ${GITHUB_SHA}"
 
   GenerateTypings:
     name: Generate TypeScript, and SDL type information

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -73,10 +73,6 @@ jobs:
         run: yarn docs
       - name: Publish Docs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-          GITHUB_ACTOR: Favware-bot
-          GITHUB_EMAIL: favwarebot@gmail.com
         run: |
           REPO="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           echo -e "\n# Checkout the repo in the target branch"
@@ -101,6 +97,10 @@ jobs:
           git config user.email "${GITHUB_EMAIL}"
           git commit -m "docs: magidocs docs build for ${GITHUB_SHA}" || true
           git push origin $TARGET_BRANCH
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_ACTOR: Favware-bot
+          GITHUB_EMAIL: favwarebot@gmail.com
 
   GenerateTypings:
     name: Generate TypeScript, and SDL type information

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -56,7 +56,6 @@ jobs:
   GenerateDocumentation:
     name: Generate Static Documentation
     runs-on: ubuntu-latest
-    needs: Publish
     steps:
       - name: Checkout Project
         uses: actions/checkout@v3
@@ -75,17 +74,33 @@ jobs:
       - name: Publish Docs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_ACTOR: Favware-bot
+          GITHUB_EMAIL: favwarebot@gmail.com
         run: |
-          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git config --global user.email "favwarebot@gmail.com"
-          git config --global user.name "Favware-bot"
-          echo "User-agent: *\nDisallow:" >> docs/robots.txt
-          touch docs/.nojekyll
-          cp .all-contributorsrc docs/
-          cp LICENSE.md docs/
-          cp README.md docs/
-          npx gh-pages --dist docs --dotfiles true --message "docs: magidocs docs build for ${GITHUB_SHA}"
+          REPO="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          echo -e "\n# Checkout the repo in the target branch"
+          TARGET_BRANCH="gh-pages"
+          git clone $REPO out -b $TARGET_BRANCH
+          echo -e "\n# Remove any old files in the out folder"
+          rm -rfv out/_app/*
+          rm -rfv out/introduction/*
+          rm -rfv out/queries/*
+          rm -rfv out/types/*
+          rm -rfv out/*.html
+          rm -rfv out/vite-manifest.json
+          echo -e "\n# Move the generated docs to the newly-checked-out repo, to be committed and pushed"
+          rsync -vaI .all-contributorsrc out/
+          rsync -vaI LICENSE.md out/
+          rsync -vaI README.md out/
+          rsync -vaI docs/ out/
+          echo -e "\n# Commit and push"
+          cd out
+          git add --all .
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_EMAIL}"
+          git commit -m "docs: magidocs docs build for ${GITHUB_SHA}" || true
+          git push origin $TARGET_BRANCH
 
   GenerateTypings:
     name: Generate TypeScript, and SDL type information

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -56,7 +56,7 @@ jobs:
   GenerateDocumentation:
     name: Generate Static Documentation
     runs-on: ubuntu-latest
-    # needs: Publish
+    needs: Publish
     steps:
       - name: Checkout Project
         uses: actions/checkout@v3

--- a/magidoc.mjs
+++ b/magidoc.mjs
@@ -9,8 +9,8 @@ const CommonURL = 'https://graphqlpokemon.js.org';
  */
 const config = {
   introspection: {
-    type: 'url',
-    url: 'http://localhost:4000'
+    type: 'sdl',
+    paths: ['./graphql/*.graphql']
   },
   website: {
     template: 'carbon-multi-page',


### PR DESCRIPTION
 - Change the documentation to be built from `sdl` rather than using introspection. It's simpler for you, faster and will enable more features in the future.
 - Simplified to use [gh-pages](https://www.npmjs.com/package/gh-pages) for the deployment. It basically does something similar to the previous script.

See the output here https://pelletier197.github.io/graphql-pokemon. It should deploy itself automatically.

For the record, the default welcome page and the magidoc icon will both be displayed. If you wish to modify the welcome page, have a look at the `pages` property in the [configuration](https://magidoc.js.org/cli/magidoc-configuration#website). Thanks again for trying it out!  

Resolves : #698 